### PR TITLE
Handle modifiers starting with multiple underscores correctly

### DIFF
--- a/src/languages/bqn.js
+++ b/src/languages/bqn.js
@@ -51,7 +51,7 @@ export default function(hljs) {
     },
     {
       scope: 'built_in',
-      match: "\\b_[A-Za-z][_A-Za-z¯π∞0-9]*_\\b",
+      match: "\\b_+[A-Za-z][_A-Za-z¯π∞0-9]*_\\b",
       relevance: 0
     },
     {
@@ -61,7 +61,7 @@ export default function(hljs) {
     },
     {
       scope: 'operator',
-      match: "\\b_[A-Za-z][_A-Za-z¯π∞0-9]*[^_]\\b",
+      match: "\\b_+[A-Za-z][_A-Za-z¯π∞0-9]*[^_]\\b",
       relevance: 0
     },
     {


### PR DESCRIPTION
As the title says,
![スクリーンショット 2023-07-04 17 33 16](https://github.com/razetime/highlightjs-bqn/assets/997855/34772ece-6a2b-495e-a743-796cab27053f)
the left side is by the current version, and the right side is by this PR.
